### PR TITLE
update readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] Q2 2022
+ - update readme to point to pre-built-libs in blob storage
+
 ## [0.3.0] Q2 2022
  - added iot edge support
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure-iot-sdk-sys"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Joerg Zeidler <joerg.zeidler@conplement.de>", "Jan Zachmann <jan.zachmann@conplement.de>"]
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ You're free to build your own versions of libraries for the target platform of y
 
 ## Use prebuild libraries for x86_64
 
-For your convenience we provide for x86_64 a bundle of libraries, created on Ubuntu 20.04lts, as part of our github release. Please find the library archive [here](https://github.com/ICS-DeviceManagement/azure-iot-sdk-sys/releases/latest) 
+For your convenience we provide a bundle of libraries for the following architectures:
+- [x86_64](https://storageicsdmassets.blob.core.windows.net/pre-built-libs-x86/pre-built-libs-1.tar.xz) 
+- [aarch64](https://storageicsdmassets.blob.core.windows.net/pre-built-libs-aarch64/pre-built-libs-1.tar.xz)
+- [armv7hf](https://storageicsdmassets.blob.core.windows.net/pre-built-libs-armv7hf/pre-built-libs-1.tar.xz)
 
 ## Enable iot edge support
 


### PR DESCRIPTION
this PR will be replaced soon by switching to debian packages for library dependencies instead of linking to pre-built-libs archive on blob storage